### PR TITLE
v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [v1.0.0] - 2022-03-30
+## [v0.0.3] - 2022-03-30
+### Added
+### Changed
+ - `$include`s now can render the text they fetch, or continue to emit JSML
+### Fixed
+ - functional tags now evaluate their arguments
+
+## [v0.0.1] - 2022-03-30
 ### Added
  - Initial Release
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "_team_name_undecided_",
+    "name": "jstempl",
     "type": "module",
     "main": "build/template.js",
-    "version": "v0.0.2",
+    "version": "v0.0.3",
     "scripts": {
         "build": "esbuild src/esm.ts --bundle --sourcemap --outfile=build/template.js --format=esm --platform=node --external:markdown-it",
         "build:standalone": "esbuild src/cjs.ts --bundle --sourcemap --outfile=build/template-standalone.cjs --platform=node",

--- a/src/build.ts
+++ b/src/build.ts
@@ -131,7 +131,7 @@ export async function* compile(jsml: NestedToken, variables: { [name: string]: a
             if ('type' in i)
                 if (isTag(i))
                     if (i.body.tagName.startsWith("$") && i.body.tagName.slice(1) in functions)
-                        yield* concatIterator([indent], functions[i.body.tagName.slice(1)](i.body, glob));
+                        yield* concatIterator([indent], functions[i.body.tagName.slice(1)]({ ...i.body, attributes: _.mapValues(i.body.attributes, i => attr(i)) }, glob));
                     else if (i.body.hasBody && 'children' in i.body)
                         yield* concatIterator([indent, `<${i.body.tagName}${evalAttr(i.body.attributes)}>`], render(i.body.children, depth + 1), [indent, `</${i.body.tagName}>`]);
                     else

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -21,12 +21,18 @@ export const loaders: Record<string, (text: string) => string> = {
 
 export const functions: Record<string, (tag: { tagName: string, hasBody: boolean, attributes: { [x in string]: string }, children?: OutNestedToken }, env: { [key in string]: any }) => AsyncGenerator<string>> = {
     async *include(tag, env) {
-        if (!('file' in tag.attributes))
-            throw `Required attribute 'file' not present on include`;
-        const file = await fs.readFile(tag.attributes.file, 'utf8');
+        if ('content_type' in tag.attributes && tag.attributes.content_type !== 'text/jsml') {
+            const file = await fs.readFile(tag.attributes.file, 'utf8');
 
-        for await (const i of compile(parseJSML('\n' + file.trim()), _.merge({}, tag.attributes, env)))
-            yield i;
+            yield loaders[tag.attributes.content_type](file);
+        } else {
+            if (!('file' in tag.attributes))
+                throw `Required attribute 'file' not present on include`;
+            const file = await fs.readFile(tag.attributes.file, 'utf8');
+
+            for await (const i of compile(parseJSML('\n' + file.trim()), _.merge({}, tag.attributes, env)))
+                yield i;
+        }
     },
     async *render(tag) {
         return [];


### PR DESCRIPTION
## [v0.0.3] - 2022-03-30
### Added
### Changed
 - `$include`s now can render the text they fetch, or continue to emit JSML
### Fixed
 - functional tags now evaluate their arguments